### PR TITLE
Benchmarking and synchronously accessing counter

### DIFF
--- a/src/main/java/com/dreamteam/os/lab2/SpinLock.java
+++ b/src/main/java/com/dreamteam/os/lab2/SpinLock.java
@@ -1,0 +1,4 @@
+package com.dreamteam.os.lab2;
+
+import java.util.concurrent.locks.Lock;
+

--- a/src/main/java/com/dreamteam/os/lab2/SpinLock.java
+++ b/src/main/java/com/dreamteam/os/lab2/SpinLock.java
@@ -1,4 +1,41 @@
 package com.dreamteam.os.lab2;
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 
+public class SpinLock implements Lock {
+  private AtomicReference<Thread> atomicReference = new AtomicReference<>();
+
+  @Override
+  public void lock() {
+    Thread thread = Thread.currentThread();
+    while (!atomicReference.compareAndSet(null, thread)) {}
+  }
+
+  @Override
+  public void lockInterruptibly() throws InterruptedException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean tryLock() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean tryLock(long time, TimeUnit unit) throws InterruptedException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void unlock() {
+    atomicReference.compareAndSet(Thread.currentThread(), null);
+  }
+
+  @Override
+  public Condition newCondition() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/src/main/java/com/dreamteam/os/lab2/SpinLock.java
+++ b/src/main/java/com/dreamteam/os/lab2/SpinLock.java
@@ -4,7 +4,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class SpinLock implements Lock {
   private AtomicReference<Thread> atomicReference = new AtomicReference<>();
 

--- a/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkLocks.java
+++ b/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkLocks.java
@@ -26,20 +26,24 @@ public class BenchmarkLocks {
       ExecutorService service = Executors.newFixedThreadPool( 1) ;
       service.submit(benchmarkRunnable);
       service.awaitTermination(time, timeUnit);
+
+      benchmarkRunnable.stopRunning();
+      service.shutdown();
+
       int operationsNumber = benchmarkRunnable.getOperationsCount();
       long currentStepAverage = operationsNumber / time;
 
       if (i >= warmup) {
         average += currentStepAverage;
       }
-//      else
-//      {
-//        System.out.println("Warmup: ");
-//      }
-//      System.out.println(
-//          "Average time for the operation on the current step: "
-//          + currentStepAverage
-//          + " ops/" + timeUnit);
+      else
+      {
+        System.out.println("Warmup: ");
+      }
+      System.out.println(
+          "Average time for the operation on the current step: "
+          + currentStepAverage
+          + " ops/" + timeUnit);
     }
 
     average = average / iterations;

--- a/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkLocks.java
+++ b/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkLocks.java
@@ -1,0 +1,64 @@
+package com.dreamteam.os.lab2.benchmarking;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+
+public class BenchmarkLocks {
+  private int iterations;
+  private TimeUnit timeUnit;
+  private long time;
+  private int warmup;
+
+  public BenchmarkLocks(int iterations, int warmup, long time, TimeUnit timeUnit) {
+    this.iterations = iterations;
+    this.time = time;
+    this.timeUnit = timeUnit;
+    this.warmup = warmup;
+  }
+
+  public void measurePerformance(Lock lock) throws InterruptedException {
+    int totalIterations = iterations + warmup;
+    long average = 0;
+    for (int i = 0; i < totalIterations; i++) {
+      BenchmarkRunnable benchmarkRunnable = new BenchmarkRunnable(lock);
+      ExecutorService service = Executors.newFixedThreadPool( 1) ;
+      service.submit(benchmarkRunnable);
+      service.awaitTermination(time, timeUnit);
+      int operationsNumber = benchmarkRunnable.getOperationsCount();
+      long currentStepAverage = operationsNumber / time;
+
+      if (i >= warmup) {
+        average += currentStepAverage;
+      }
+//      else
+//      {
+//        System.out.println("Warmup: ");
+//      }
+//      System.out.println(
+//          "Average time for the operation on the current step: "
+//          + currentStepAverage
+//          + " ops/" + timeUnit);
+    }
+
+    average = average / iterations;
+    System.out.println("Average time = " + average + " ops/" + timeUnit);
+  }
+
+  public void setTimeUnit(TimeUnit timeUnit) {
+    this.timeUnit = timeUnit;
+  }
+
+  public TimeUnit getTimeUnit() {
+    return timeUnit;
+  }
+
+  public void setTime(int time) {
+    this.time = time;
+  }
+
+  public long getTime() {
+    return time;
+  }
+}

--- a/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkLocks.java
+++ b/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkLocks.java
@@ -27,12 +27,11 @@ public class BenchmarkLocks {
     for (int i = 0; i < totalIterations; i++) {
       BenchmarkRunnable benchmarkRunnable = new BenchmarkRunnable(lock);
 
-      ExecutorService service = Executors.newFixedThreadPool( 1) ;
+      ExecutorService service = Executors.newFixedThreadPool(1);
       service.submit(benchmarkRunnable);
       service.awaitTermination(time, timeUnit);
       benchmarkRunnable.stopRunning();
       service.shutdown();
-
 
       int operationsNumber = benchmarkRunnable.getOperationsCount();
       long currentStepAverage = operationsNumber / time;
@@ -47,7 +46,8 @@ public class BenchmarkLocks {
         System.out.println(
             "Average time for the operation on the current step: "
                 + currentStepAverage
-                + " ops/" + timeUnit);
+                + " ops/"
+                + timeUnit);
       }
     }
 

--- a/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkRunnable.java
+++ b/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkRunnable.java
@@ -34,8 +34,7 @@ public class BenchmarkRunnable implements Runnable {
     if (lock instanceof AbstractFixnumLock) ((AbstractFixnumLock) lock).unregister();
   }
 
-  public void stopRunning()
-  {
+  public void stopRunning() {
     isRunning = false;
   }
 

--- a/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkRunnable.java
+++ b/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkRunnable.java
@@ -1,0 +1,25 @@
+package com.dreamteam.os.lab2.benchmarking;
+
+import java.util.concurrent.locks.Lock;
+
+public class BenchmarkRunnable implements Runnable {
+  private Lock lock;
+  private int operationsCount = 0;
+
+  public BenchmarkRunnable(Lock lock) {
+    this.lock = lock;
+  }
+
+  @Override
+  public void run() {
+    while (!Thread.currentThread().isInterrupted()) {
+      lock.lock();
+      lock.unlock();
+      operationsCount++;
+    }
+  }
+
+  public int getOperationsCount() {
+    return operationsCount;
+  }
+}

--- a/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkRunnable.java
+++ b/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkRunnable.java
@@ -5,6 +5,7 @@ import java.util.concurrent.locks.Lock;
 public class BenchmarkRunnable implements Runnable {
   private Lock lock;
   private int operationsCount = 0;
+  private volatile boolean isRunning = true;
 
   public BenchmarkRunnable(Lock lock) {
     this.lock = lock;
@@ -12,11 +13,16 @@ public class BenchmarkRunnable implements Runnable {
 
   @Override
   public void run() {
-    while (!Thread.currentThread().isInterrupted()) {
+    while (isRunning) {
       lock.lock();
       lock.unlock();
       operationsCount++;
     }
+  }
+
+  public void stopRunning()
+  {
+    isRunning = false;
   }
 
   public int getOperationsCount() {

--- a/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkRunnable.java
+++ b/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkRunnable.java
@@ -1,23 +1,37 @@
 package com.dreamteam.os.lab2.benchmarking;
 
+import com.dreamteam.os.lab2.AbstractFixnumLock;
 import java.util.concurrent.locks.Lock;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class BenchmarkRunnable implements Runnable {
   private Lock lock;
   private int operationsCount = 0;
-  private volatile boolean isRunning = true;
+  private volatile boolean isRunning;
 
   public BenchmarkRunnable(Lock lock) {
     this.lock = lock;
+    this.isRunning = true;
   }
 
   @Override
   public void run() {
+    registerLock();
     while (isRunning) {
       lock.lock();
       lock.unlock();
       operationsCount++;
     }
+    deregisterLock();
+  }
+
+  public void registerLock() {
+    if (lock instanceof AbstractFixnumLock) ((AbstractFixnumLock) lock).register();
+  }
+
+  public void deregisterLock() {
+    if (lock instanceof AbstractFixnumLock) ((AbstractFixnumLock) lock).unregister();
   }
 
   public void stopRunning()

--- a/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkStatistics.java
+++ b/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkStatistics.java
@@ -7,8 +7,8 @@ import java.util.concurrent.locks.ReentrantLock;
 
 public class BenchmarkStatistics {
   public static void main(String[] args) throws InterruptedException {
-    DekkersLock lock = new DekkersLock();
-    BenchmarkLocks benchmarkLocks = new BenchmarkLocks(10, 15, 4000, TimeUnit.MILLISECONDS);
+    ReentrantLock lock = new ReentrantLock();
+    BenchmarkLocks benchmarkLocks = new BenchmarkLocks(10, 15, 1000, TimeUnit.MILLISECONDS);
     benchmarkLocks.measurePerformance(lock);
   }
 }

--- a/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkStatistics.java
+++ b/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkStatistics.java
@@ -2,6 +2,7 @@ package com.dreamteam.os.lab2.benchmarking;
 
 import com.dreamteam.os.lab2.BakeryLock;
 import com.dreamteam.os.lab2.DekkersLock;
+import com.dreamteam.os.lab2.ImprovedBakeryLock;
 import com.dreamteam.os.lab2.SpinLock;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
@@ -18,17 +19,22 @@ public class BenchmarkStatistics {
     DekkersLock dekkersLock = new DekkersLock();
     SpinLock spinLock = new SpinLock();
     ReentrantLock reentrantLock = new ReentrantLock();
+    ImprovedBakeryLock improvedBakeryLock = new ImprovedBakeryLock(1);
 
     System.out.println("Performance of the Bakery Lock: "); // 23960 ops/MILLISECOND
     benchmarkPerformance.measurePerformance(bakeryLock);
 
+//    System.out.println("Performance of the Improved Bakery Lock"); // 11435 ops/MILLISECOND
+//    benchmarkPerformance.measurePerformance(improvedBakeryLock);
+
     System.out.println("Performance of the Dekker's Lock: "); // 35375 ops/MILLISECOND
     benchmarkPerformance.measurePerformance(dekkersLock);
 
-    System.out.println("Performance of the Spin Lock"); // 48973 ops/MILLISECOND
+    System.out.println("Performance of the Spin Lock:"); // 48973 ops/MILLISECOND
     benchmarkPerformance.measurePerformance(spinLock);
 
     System.out.println("Performance of the Reentrant Lock"); // 50690 ops/MILLISECOND
     benchmarkPerformance.measurePerformance(reentrantLock);
+
   }
 }

--- a/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkStatistics.java
+++ b/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkStatistics.java
@@ -1,0 +1,14 @@
+package com.dreamteam.os.lab2.benchmarking;
+
+
+import com.dreamteam.os.lab2.DekkersLock;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class BenchmarkStatistics {
+  public static void main(String[] args) throws InterruptedException {
+    DekkersLock lock = new DekkersLock();
+    BenchmarkLocks benchmarkLocks = new BenchmarkLocks(10, 15, 4000, TimeUnit.MILLISECONDS);
+    benchmarkLocks.measurePerformance(lock);
+  }
+}

--- a/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkStatistics.java
+++ b/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkStatistics.java
@@ -24,8 +24,8 @@ public class BenchmarkStatistics {
     System.out.println("Performance of the Bakery Lock: "); // 23960 ops/MILLISECOND
     benchmarkPerformance.measurePerformance(bakeryLock);
 
-//    System.out.println("Performance of the Improved Bakery Lock"); // 11435 ops/MILLISECOND
-//    benchmarkPerformance.measurePerformance(improvedBakeryLock);
+    //    System.out.println("Performance of the Improved Bakery Lock"); // 11435 ops/MILLISECOND
+    //    benchmarkPerformance.measurePerformance(improvedBakeryLock);
 
     System.out.println("Performance of the Dekker's Lock: "); // 35375 ops/MILLISECOND
     benchmarkPerformance.measurePerformance(dekkersLock);
@@ -35,6 +35,5 @@ public class BenchmarkStatistics {
 
     System.out.println("Performance of the Reentrant Lock"); // 50690 ops/MILLISECOND
     benchmarkPerformance.measurePerformance(reentrantLock);
-
   }
 }

--- a/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkStatistics.java
+++ b/src/main/java/com/dreamteam/os/lab2/benchmarking/BenchmarkStatistics.java
@@ -1,14 +1,34 @@
 package com.dreamteam.os.lab2.benchmarking;
 
-
+import com.dreamteam.os.lab2.BakeryLock;
 import com.dreamteam.os.lab2.DekkersLock;
+import com.dreamteam.os.lab2.SpinLock;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.LogManager;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class BenchmarkStatistics {
   public static void main(String[] args) throws InterruptedException {
-    ReentrantLock lock = new ReentrantLock();
-    BenchmarkLocks benchmarkLocks = new BenchmarkLocks(10, 15, 1000, TimeUnit.MILLISECONDS);
-    benchmarkLocks.measurePerformance(lock);
+    LogManager.getLogManager().reset();
+    BenchmarkLocks benchmarkPerformance = new BenchmarkLocks(5, 2, 1000, TimeUnit.MILLISECONDS);
+
+    BakeryLock bakeryLock = new BakeryLock(1);
+    DekkersLock dekkersLock = new DekkersLock();
+    SpinLock spinLock = new SpinLock();
+    ReentrantLock reentrantLock = new ReentrantLock();
+
+    System.out.println("Performance of the Bakery Lock: "); // 23960 ops/MILLISECOND
+    benchmarkPerformance.measurePerformance(bakeryLock);
+
+    System.out.println("Performance of the Dekker's Lock: "); // 35375 ops/MILLISECOND
+    benchmarkPerformance.measurePerformance(dekkersLock);
+
+    System.out.println("Performance of the Spin Lock"); // 48973 ops/MILLISECOND
+    benchmarkPerformance.measurePerformance(spinLock);
+
+    System.out.println("Performance of the Reentrant Lock"); // 50690 ops/MILLISECOND
+    benchmarkPerformance.measurePerformance(reentrantLock);
   }
 }

--- a/src/main/java/com/dreamteam/os/lab2/experiment/AccessCounter.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/AccessCounter.java
@@ -4,8 +4,17 @@ import com.dreamteam.os.lab2.experiment.types.CounterTypes;
 
 public class AccessCounter {
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws InterruptedException {
     System.out.println("Atomic counter: ");
     AccessCounterTest.testCounter(CounterTypes.ATOMIC);
+
+    System.out.println("Read-write lock counter: ");
+    AccessCounterTest.testCounter(CounterTypes.READ_WRITE_LOCK);
+
+    System.out.println("Spin lock counter: ");
+    AccessCounterTest.testCounter(CounterTypes.SPIN_LOCK);
+
+    System.out.println("Synchronized counter: ");
+    AccessCounterTest.testCounter(CounterTypes.SYNCHRONIZED);
   }
 }

--- a/src/main/java/com/dreamteam/os/lab2/experiment/AccessCounter.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/AccessCounter.java
@@ -1,0 +1,11 @@
+package com.dreamteam.os.lab2.experiment;
+
+import com.dreamteam.os.lab2.experiment.types.CounterTypes;
+
+public class AccessCounter {
+
+  public static void main(String[] args) {
+    System.out.println("Atomic counter: ");
+    AccessCounterTest.testCounter(CounterTypes.ATOMIC);
+  }
+}

--- a/src/main/java/com/dreamteam/os/lab2/experiment/AccessCounterTest.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/AccessCounterTest.java
@@ -18,7 +18,7 @@ public class AccessCounterTest {
   private static volatile boolean resultPrinted = false;
   private static ArrayList<RunnableWithCancellation> runnables;
 
-  public static void testCounter(CounterTypes counterType) {
+  public static void testCounter(CounterTypes counterType) throws InterruptedException {
     resultPrinted = false;
     runnables = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
@@ -29,13 +29,14 @@ public class AccessCounterTest {
 
       for (int j = 0; j < threadNumber; j += 2) {
         RunnableWithCancellation consumer = new Consumer(counter);
-        RunnableWithCancellation producer = new Producer(counter, 100000000L);
+        RunnableWithCancellation producer = new Producer(counter, 1000000L);
         runnables.add(consumer);
         runnables.add(producer);
         service.submit((Runnable) consumer);
         service.submit((Runnable) producer);
       }
     }
+    service.awaitTermination(10, TimeUnit.MINUTES);
   }
 
   public static void printResult(long endTime) {

--- a/src/main/java/com/dreamteam/os/lab2/experiment/AccessCounterTest.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/AccessCounterTest.java
@@ -1,0 +1,63 @@
+package com.dreamteam.os.lab2.experiment;
+
+import com.dreamteam.os.lab2.experiment.types.Atomic;
+import com.dreamteam.os.lab2.experiment.types.CounterTypes;
+import com.dreamteam.os.lab2.experiment.types.ReadWriteLockCounter;
+import com.dreamteam.os.lab2.experiment.types.SpinLockCounter;
+import com.dreamteam.os.lab2.experiment.types.Synchronized;
+import java.util.ArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public class AccessCounterTest {
+  public static int threadNumber = 10;
+  private static ExecutorService service;
+  private static long start;
+  private static volatile boolean resultPrinted = false;
+  private static ArrayList<RunnableWithCancellation> runnables;
+
+  public static void testCounter(CounterTypes counterType) {
+    resultPrinted = false;
+    runnables = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      Counter counter = getCounter(counterType);
+
+      service = Executors.newFixedThreadPool(threadNumber);
+      start = System.currentTimeMillis();
+
+      for (int j = 0; j < threadNumber; j += 2) {
+        RunnableWithCancellation consumer = new Consumer(counter);
+        RunnableWithCancellation producer = new Producer(counter, 100000000L);
+        runnables.add(consumer);
+        runnables.add(producer);
+        service.submit((Runnable) consumer);
+        service.submit((Runnable) producer);
+      }
+    }
+  }
+
+  public static void printResult(long endTime) {
+    for (RunnableWithCancellation runnable : runnables) {
+      runnable.stopRunning();
+    }
+    if (!resultPrinted) System.out.println("Result = " + (endTime - start));
+    resultPrinted = true;
+    service.shutdownNow();
+  }
+
+  private static Counter getCounter(CounterTypes counterType) {
+    switch (counterType) {
+      case ATOMIC:
+        return new Atomic();
+      case READ_WRITE_LOCK:
+        return new ReadWriteLockCounter();
+      case SPIN_LOCK:
+        return new SpinLockCounter();
+      case SYNCHRONIZED:
+        return new Synchronized();
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/dreamteam/os/lab2/experiment/Consumer.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/Consumer.java
@@ -1,0 +1,24 @@
+package com.dreamteam.os.lab2.experiment;
+
+public class Consumer implements Runnable, RunnableWithCancellation {
+
+  private final Counter counter;
+  private volatile boolean isRunning = true;
+
+  public Consumer(Counter counter)
+  {
+    this.counter = counter;
+  }
+
+  @Override
+  public void run() {
+    while (isRunning) {
+      long count = counter.getCounter();
+    }
+  }
+
+  public void stopRunning()
+  {
+    isRunning = false;
+  }
+}

--- a/src/main/java/com/dreamteam/os/lab2/experiment/Consumer.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/Consumer.java
@@ -5,8 +5,7 @@ public class Consumer implements Runnable, RunnableWithCancellation {
   private final Counter counter;
   private volatile boolean isRunning = true;
 
-  public Consumer(Counter counter)
-  {
+  public Consumer(Counter counter) {
     this.counter = counter;
   }
 
@@ -17,8 +16,7 @@ public class Consumer implements Runnable, RunnableWithCancellation {
     }
   }
 
-  public void stopRunning()
-  {
+  public void stopRunning() {
     isRunning = false;
   }
 }

--- a/src/main/java/com/dreamteam/os/lab2/experiment/Counter.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/Counter.java
@@ -2,5 +2,6 @@ package com.dreamteam.os.lab2.experiment;
 
 public interface Counter {
   public long getCounter();
+
   public void increment();
 }

--- a/src/main/java/com/dreamteam/os/lab2/experiment/Counter.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/Counter.java
@@ -1,0 +1,6 @@
+package com.dreamteam.os.lab2.experiment;
+
+public interface Counter {
+  public long getCounter();
+  public void increment();
+}

--- a/src/main/java/com/dreamteam/os/lab2/experiment/Producer.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/Producer.java
@@ -5,8 +5,7 @@ public class Producer implements Runnable, RunnableWithCancellation {
   private long targetNumber;
   private volatile boolean isRunning = true;
 
-  public Producer(Counter counter, long targetNumber)
-  {
+  public Producer(Counter counter, long targetNumber) {
     this.counter = counter;
     this.targetNumber = targetNumber;
   }
@@ -22,8 +21,7 @@ public class Producer implements Runnable, RunnableWithCancellation {
     }
   }
 
-  public void stopRunning()
-  {
+  public void stopRunning() {
     isRunning = false;
   }
 }

--- a/src/main/java/com/dreamteam/os/lab2/experiment/Producer.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/Producer.java
@@ -1,0 +1,29 @@
+package com.dreamteam.os.lab2.experiment;
+
+public class Producer implements Runnable, RunnableWithCancellation {
+  private final Counter counter;
+  private long targetNumber;
+  private volatile boolean isRunning = true;
+
+  public Producer(Counter counter, long targetNumber)
+  {
+    this.counter = counter;
+    this.targetNumber = targetNumber;
+  }
+
+  @Override
+  public void run() {
+    while (isRunning) {
+      counter.increment();
+      if (counter.getCounter() > targetNumber) {
+        AccessCounterTest.printResult(System.currentTimeMillis());
+        isRunning = false;
+      }
+    }
+  }
+
+  public void stopRunning()
+  {
+    isRunning = false;
+  }
+}

--- a/src/main/java/com/dreamteam/os/lab2/experiment/RunnableWithCancellation.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/RunnableWithCancellation.java
@@ -1,0 +1,5 @@
+package com.dreamteam.os.lab2.experiment;
+
+public interface RunnableWithCancellation {
+  void stopRunning();
+}

--- a/src/main/java/com/dreamteam/os/lab2/experiment/types/Atomic.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/types/Atomic.java
@@ -1,0 +1,18 @@
+package com.dreamteam.os.lab2.experiment.types;
+
+import com.dreamteam.os.lab2.experiment.Counter;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class Atomic implements Counter {
+  private final AtomicLong atomic = new AtomicLong();
+
+  @Override
+  public long getCounter() {
+    return atomic.get();
+  }
+
+  @Override
+  public void increment() {
+    atomic.incrementAndGet();
+  }
+}

--- a/src/main/java/com/dreamteam/os/lab2/experiment/types/CounterTypes.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/types/CounterTypes.java
@@ -1,0 +1,8 @@
+package com.dreamteam.os.lab2.experiment.types;
+
+public enum CounterTypes {
+  ATOMIC,
+  READ_WRITE_LOCK,
+  SPIN_LOCK,
+  SYNCHRONIZED
+}

--- a/src/main/java/com/dreamteam/os/lab2/experiment/types/ReadWriteLockCounter.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/types/ReadWriteLockCounter.java
@@ -8,15 +8,13 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 public class ReadWriteLockCounter implements Counter {
   private ReadWriteLock rwlock = new ReentrantReadWriteLock();
 
-  private Lock readLock = rwlock.readLock();
-  private Lock writeLock = rwlock.writeLock();
+  private final Lock readLock = rwlock.readLock();
+  private final Lock writeLock = rwlock.writeLock();
   private long counter;
 
   @Override
-  public long getCounter()
-  {
-    try
-    {
+  public long getCounter() {
+    try {
       readLock.lock();
       return counter;
     } finally {
@@ -25,10 +23,8 @@ public class ReadWriteLockCounter implements Counter {
   }
 
   @Override
-  public void increment()
-  {
-    try
-    {
+  public void increment() {
+    try {
       writeLock.lock();
       ++counter;
     } finally {

--- a/src/main/java/com/dreamteam/os/lab2/experiment/types/ReadWriteLockCounter.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/types/ReadWriteLockCounter.java
@@ -1,0 +1,38 @@
+package com.dreamteam.os.lab2.experiment.types;
+
+import com.dreamteam.os.lab2.experiment.Counter;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class ReadWriteLockCounter implements Counter {
+  private ReadWriteLock rwlock = new ReentrantReadWriteLock();
+
+  private Lock readLock = rwlock.readLock();
+  private Lock writeLock = rwlock.writeLock();
+  private long counter;
+
+  @Override
+  public long getCounter()
+  {
+    try
+    {
+      readLock.lock();
+      return counter;
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  @Override
+  public void increment()
+  {
+    try
+    {
+      writeLock.lock();
+      ++counter;
+    } finally {
+      writeLock.unlock();
+    }
+  }
+}

--- a/src/main/java/com/dreamteam/os/lab2/experiment/types/SpinLockCounter.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/types/SpinLockCounter.java
@@ -1,0 +1,34 @@
+package com.dreamteam.os.lab2.experiment.types;
+
+import com.dreamteam.os.lab2.SpinLock;
+import com.dreamteam.os.lab2.experiment.Counter;
+
+public class SpinLockCounter implements Counter {
+  private SpinLock lock = new SpinLock();
+  private long counter;
+
+  @Override
+  public long getCounter()
+  {
+    try
+    {
+      lock.lock();
+      return counter;
+    } finally {
+      lock.unlock();
+    }
+
+  }
+
+  @Override
+  public void increment()
+  {
+    try
+    {
+      lock.lock();
+      ++counter;
+    } finally {
+      lock.unlock();
+    }
+  }
+}

--- a/src/main/java/com/dreamteam/os/lab2/experiment/types/SpinLockCounter.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/types/SpinLockCounter.java
@@ -8,23 +8,18 @@ public class SpinLockCounter implements Counter {
   private long counter;
 
   @Override
-  public long getCounter()
-  {
-    try
-    {
+  public long getCounter() {
+    try {
       lock.lock();
       return counter;
     } finally {
       lock.unlock();
     }
-
   }
 
   @Override
-  public void increment()
-  {
-    try
-    {
+  public void increment() {
+    try {
       lock.lock();
       ++counter;
     } finally {

--- a/src/main/java/com/dreamteam/os/lab2/experiment/types/Synchronized.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/types/Synchronized.java
@@ -1,0 +1,26 @@
+package com.dreamteam.os.lab2.experiment.types;
+
+import com.dreamteam.os.lab2.experiment.Counter;
+
+public class Synchronized implements Counter {
+  private final Object lock = new Object();
+  private int counter;
+
+  @Override
+  public long getCounter()
+  {
+    synchronized (lock)
+    {
+      return counter;
+    }
+  }
+
+  @Override
+  public void increment()
+  {
+    synchronized (lock)
+    {
+      ++counter;
+    }
+  }
+}

--- a/src/main/java/com/dreamteam/os/lab2/experiment/types/Synchronized.java
+++ b/src/main/java/com/dreamteam/os/lab2/experiment/types/Synchronized.java
@@ -7,19 +7,15 @@ public class Synchronized implements Counter {
   private int counter;
 
   @Override
-  public long getCounter()
-  {
-    synchronized (lock)
-    {
+  public long getCounter() {
+    synchronized (lock) {
       return counter;
     }
   }
 
   @Override
-  public void increment()
-  {
-    synchronized (lock)
-    {
+  public void increment() {
+    synchronized (lock) {
       ++counter;
     }
   }


### PR DESCRIPTION
Experiment with threads synchronously accessing counter using atomic, spinlock, monitor primitives etc. Utilize java.util.concurrent.Lock interface or Lockable concept to implement benchmarking framework. Implement missing primitives (such as spinlock in Java) and use primitives implemented in 1, 3, 5. Compare performances of different primitives. Try to estimate thread contention.